### PR TITLE
Fully automate dev setup with Gitpod

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,7 @@
+FROM gitpod/workspace-mysql
+
+# Install custom tools, runtimes, etc.
+# For example "bastet", a command-line tetris clone:
+# RUN brew install bastet
+#
+# More information: https://www.gitpod.io/docs/config-docker/

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,6 @@
+image:
+  file: .gitpod.Dockerfile
+
+tasks:
+  - init: go get && go build ./... && go test ./... && make
+    command: go run

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 [![Build on Linux](https://github.com/ledyba/prometheus_sql_adapter/workflows/Build%20on%20Linux/badge.svg)](https://github.com/ledyba/prometheus_sql_adapter/actions?query=workflow%3A%22Build+on+Linux%22)
 [![Build on macOS](https://github.com/ledyba/prometheus_sql_adapter/workflows/Build%20on%20macOS/badge.svg)](https://github.com/ledyba/prometheus_sql_adapter/actions?query=workflow%3A%22Build+on+macOS%22)
 [![Build on Windows](https://github.com/ledyba/prometheus_sql_adapter/workflows/Build%20on%20Windows/badge.svg)](https://github.com/ledyba/prometheus_sql_adapter/actions?query=workflow%3A%22Build+on+Windows%22)  
-[![Build single binary on Linux](https://github.com/ledyba/prometheus_sql_adapter/workflows/Build%20single%20binary%20on%20Linux/badge.svg)](https://github.com/ledyba/prometheus_sql_adapter/actions?query=workflow%3A%22Build+single+binary+on+Linux%22)
- 
+[![Build single binary on Linux](https://github.com/ledyba/prometheus_sql_adapter/workflows/Build%20single%20binary%20on%20Linux/badge.svg)](https://github.com/ledyba/prometheus_sql_adapter/actions?query=workflow%3A%22Build+single+binary+on+Linux%22)  
+[![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/ledyba/prometheus_sql_adapter)
 
 Prometheus remote storage adapter, which stores timeseries data into RDBMS.
 


### PR DESCRIPTION
This commit implements a fully-automated development setup using Gitpod.io, an
online IDE for GitHub and GitLab that enables Dev-Environments-As-Code.
This makes it easy for anyone to get a ready-to-code workspace for any branch,
issue or pull request almost instantly with a single click.